### PR TITLE
Add pid path for awx-celery-beat systemd unit file

### DIFF
--- a/awx-celery-beat.service
+++ b/awx-celery-beat.service
@@ -7,7 +7,7 @@ EnvironmentFile=-/etc/sysconfig/awx
 Environment=PYTHONPATH=/opt/awx/embedded/lib/python2.7/site-packages:/opt/awx/embedded/lib64/python2.7/site-packages
 Environment=AWX_SETTINGS_FILE=/etc/awx/settings.py
 Environment=PATH=/opt/awx/bin:/bin:/sbin:/usr/bin:/usr/sbin
-ExecStart=/opt/awx/bin/awx-manage celery beat -l info --pidfile= -s
+ExecStart=/opt/awx/bin/awx-manage celery beat -l info --pidfile= -s /var/opt/awx/beat.db
 KillMode=process
 Restart=on-failure
 RestartSec=2s


### PR DESCRIPTION
The service won't be running without that in CentOS 7